### PR TITLE
Add option to export SVG screenshot

### DIFF
--- a/webview/assets/js/snapshot.js
+++ b/webview/assets/js/snapshot.js
@@ -28,7 +28,7 @@ export const takeSnapshot = () => {
             .toSvg(snapshotContainerBackgroundNode, options)
             .then(function(dataUrl) {
                 resetStyles();
-                var link = document.createElement('a');
+                const link = document.createElement('a');
                 link.download = 'code-snapshot.svg';
                 link.href = dataUrl;
                 link.click();

--- a/webview/assets/js/snapshot.js
+++ b/webview/assets/js/snapshot.js
@@ -1,25 +1,44 @@
 const snapshotContainerNode = document.querySelector('.snapshot-container');
 const snapshotContainerBackgroundNode = document.querySelector('.snapshot-container__background');
 const terminalNode = document.querySelector('.terminal');
+const exportSvgNode = document.getElementById('export-svg');
+
+const resetStyles = () => {
+    snapshotContainerNode.style.resize = '';
+    terminalNode.style.resize = '';
+}
 
 export const takeSnapshot = () => {
     snapshotContainerNode.style.resize = 'none';
     terminalNode.style.resize = 'none';
 
-    domtoimage
-        .toBlob(snapshotContainerBackgroundNode, {
-            width: snapshotContainerBackgroundNode.offsetWidth * 2,
-            height: snapshotContainerBackgroundNode.offsetHeight * 2,
-            style: {
-                transform: 'scale(2)',
-                'transform-origin': 'center',
-                background: '#e0eafc',
-                background: 'linear-gradient(to left, #e0eafc, #cfdef3);'
-            }
-        })
-        .then(function(blob) {
-            snapshotContainerNode.style.resize = '';
-            terminalNode.style.resize = '';
-            window.saveAs(blob, 'code-snapshot.png');
-        });
+    const options = {
+        width: snapshotContainerBackgroundNode.offsetWidth * 2,
+        height: snapshotContainerBackgroundNode.offsetHeight * 2,
+        style: {
+            transform: 'scale(2)',
+            'transform-origin': 'center',
+            background: '#e0eafc',
+            background: 'linear-gradient(to left, #e0eafc, #cfdef3);'
+        }
+    };
+
+    if(exportSvgNode.checked) {
+        domtoimage
+            .toSvg(snapshotContainerBackgroundNode, options)
+            .then(function(dataUrl) {
+                resetStyles();
+                var link = document.createElement('a');
+                link.download = 'code-snapshot.svg';
+                link.href = dataUrl;
+                link.click();
+            });
+    } else {
+        domtoimage
+            .toBlob(snapshotContainerBackgroundNode, options)
+            .then(function(blob) {
+                resetStyles();
+                window.saveAs(blob, 'code-snapshot.png');
+            });
+    }
 };

--- a/webview/index.html
+++ b/webview/index.html
@@ -18,6 +18,13 @@
                         Show line numbers
                     </label>
                 </div>
+
+                <div class="header__checkbox">
+                    <input type="checkbox" id="export-svg">
+                    <label for="export-svg">
+                        Export SVG
+                    </label>
+                </div>
             </div>
             <div class="header__size"></div>
         </header>


### PR DESCRIPTION
This adds a checkbox (unselected by default) that, when checked, will cause the shutter button to export an SVG file instead of a PNG.