### PR TITLE
Implement Fix for Code Window Border Incorrectly Displaying

### DIFF
--- a/webview/assets/css/main.css
+++ b/webview/assets/css/main.css
@@ -78,6 +78,9 @@ body {
     min-width: 54px;
     min-height: 14px;
 }
+.terminal code {
+    background-color: transparent;
+}
 .terminal__header {
     margin-bottom: 15px;
 }


### PR DESCRIPTION
Noticed a weird border being display on the code windows outer edges, upon investigating I discovered there is a css class on `code` being set as such:
```css
background-color: var(--vscode-textPreformat-background);
```

This comes from the `<style id="_defaultStyles">` style block and so I'm unsure if I have conflicting user styles, or this is just a new VSCode update that's introduced it.

Nevertheless, my proposed change targets only the CodeSnap `terminal` child `code` and sets the background to transparent, thus fixing the issue.

Images to highlight issue faced and fix:
![Screenshot 2023-12-09 at 4 58 48 pm](https://github.com/robert-z/code-snapshot/assets/6904599/9075946e-227a-430b-ba28-651539405b00)
![Screenshot 2023-12-09 at 4 59 03 pm](https://github.com/robert-z/code-snapshot/assets/6904599/2279a5cf-0662-4490-aad3-a1a9b6b9d39c)

***

Love the extension btw, absolutely brilliant 👏